### PR TITLE
Atualiza Content.jsx para exibir citação e minibio

### DIFF
--- a/src/components/Content.jsx
+++ b/src/components/Content.jsx
@@ -83,9 +83,9 @@ export function Content() {
                 <details>
                   <summary className={styles.cardRepoSummary}>
                     {repo.nome}
+                    <p className={styles.cardRepoText}>{repo.minibio}</p>
+                    <q className={styles.cardRepoQuote}>{repo.citacao}</q>
                   </summary>
-                  <p className={styles.cardRepoText}>{repo.minibio}</p>
-                  <q className={styles.cardRepoQuote}>{repo.citacao}</q>
                 </details>
               </div>
               )


### PR DESCRIPTION
Esse PR corrige o problema que temos hoje em dia no site, onde não está sendo possível visualizar a citação e a minibio das mulheres cadastradas.


Antes:
<img width="496" alt="image" src="https://github.com/euprogramo/front-programaria-react/assets/74625367/1a27ece1-49c7-4210-854e-1f8545536587">

Depois:
<img width="450" alt="image" src="https://github.com/euprogramo/front-programaria-react/assets/74625367/14624830-380f-4f2e-8317-ca286d792a1c">
